### PR TITLE
fix(security): remove weak JWT default and add config validation

### DIFF
--- a/config/env.go
+++ b/config/env.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"strconv"
 	"sync"
@@ -60,7 +61,7 @@ func GetConfig() *Config {
 
 		config = &Config{
 			Port:         getEnv("PORT", "8080"),
-			JWTSecretKey: getEnv("JWT_SECRET_KEY", "secretJwtKey"),
+			JWTSecretKey: getEnv("JWT_SECRET_KEY", ""),
 			LocalStoragePath: getEnv("LOCAL_STORAGE_PATH", "videos"),
 			AWSRegion:    getEnv("AWS_REGION", ""),
 			AWSBucketName: getEnv("AWS_BUCKET_NAME", ""),
@@ -86,9 +87,27 @@ func GetConfig() *Config {
 			MinIOAccessKey:  getEnv("MINIO_ACCESS_KEY", "minioadmin"),
 			MinIOSecretKey:  getEnv("MINIO_SECRET_KEY", "minioadmin"),
 		}
+
+		validateConfig(config)
 	})
 
 	return config
+}
+
+func validateConfig(cfg *Config) {
+	if cfg.JWTSecretKey == "" {
+		panic("JWT_SECRET_KEY environment variable is required")
+	}
+	if len(cfg.JWTSecretKey) < 32 {
+		panic("JWT_SECRET_KEY must be at least 32 characters long")
+	}
+
+	if cfg.PostgresPassword == "postgres" {
+		log.Println("WARNING: using default PostgreSQL password, set POSTGRES_PASSWORD in .env")
+	}
+	if cfg.RabbitMQPassword == "guest" {
+		log.Println("WARNING: using default RabbitMQ password, set RABBITMQ_PASSWORD in .env")
+	}
 }
 
 func loadEnv() error {


### PR DESCRIPTION
Remove hardcoded "secretJwtKey" default. App now panics on startup if JWT_SECRET_KEY is missing or shorter than 32 characters. Add warnings for default PostgreSQL and RabbitMQ passwords.