### PR TITLE
fix(security): restrict CORS to configured origins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,9 @@ PORT=3003
 JWT_SECRET_KEY=your_secret_key
 LOCAL_STORAGE_PATH=./static/videos
 
+# CORS (comma-separated origins)
+CORS_ALLOWED_ORIGINS=http://localhost:3000
+
 # PostgreSQL
 POSTGRES_HOST=localhost
 POSTGRES_PORT=5432

--- a/config/env.go
+++ b/config/env.go
@@ -33,6 +33,8 @@ type Config struct {
 	RabbitMQVideoQueue     string
 	RabbitMQThumbnailQueue string
 
+	CORSAllowedOrigins string
+
 	StorageType     string
 	MinIOEndpoint   string
 	MinIOBucketName string
@@ -80,6 +82,8 @@ func GetConfig() *Config {
 			RabbitMQPassword:       getEnv("RABBITMQ_PASSWORD", "guest"),
 			RabbitMQVideoQueue:     getEnv("RABBITMQ_VIDEO_QUEUE", "video_processing"),
 			RabbitMQThumbnailQueue: getEnv("RABBITMQ_THUMBNAIL_QUEUE", "thumbnail_generation"),
+
+			CORSAllowedOrigins: getEnv("CORS_ALLOWED_ORIGINS", "http://localhost:3000"),
 
 			StorageType:     getEnv("STORAGE_TYPE", "minio"),
 			MinIOEndpoint:   getEnv("MINIO_ENDPOINT", "localhost:9000"),

--- a/main.go
+++ b/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"strings"
+
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 
@@ -21,9 +23,17 @@ import (
 
 func main() {
 
+	cfg := config.GetConfig()
+
 	r := gin.Default()
 
-	r.Use(cors.Default()) // Habilita CORS para todos los orígenes
+	allowedOrigins := strings.Split(cfg.CORSAllowedOrigins, ",")
+	r.Use(cors.New(cors.Config{
+		AllowOrigins:     allowedOrigins,
+		AllowMethods:     []string{"GET", "POST", "PATCH", "DELETE", "OPTIONS"},
+		AllowHeaders:     []string{"Authorization", "Content-Type"},
+		AllowCredentials: true,
+	}))
 
 	apiGroup := r.Group("/api")
 


### PR DESCRIPTION
Replace cors.Default() (all origins) with cors.New() using explicit allowed origins from CORS_ALLOWED_ORIGINS env var. Defaults to http://localhost:3000 for development. Supports comma-separated multiple origins.