### PR TITLE
feat: implement Register endpoint

### DIFF
--- a/internal/app/initializer.go
+++ b/internal/app/initializer.go
@@ -14,7 +14,7 @@ func InitializeComponents() (controllers.UserController, controllers.AuthControl
 
 	// Inicializa los controladores de usuario y auth
 	userController := controllers.NewUserController(userService)
-	authController := controllers.NewAuthController(authService)
+	authController := controllers.NewAuthController(authService, userService)
 
 	// Inicializa servicios de video con StorageService genérico
 	storageService := storage.NewStorageService()

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -20,6 +20,12 @@ type UserLogin struct {
 	Password string `json:"password" binding:"required"`
 }
 
+type UserRegister struct {
+	Username string `json:"username" binding:"required,min=3,max=100"`
+	Password string `json:"password" binding:"required,min=8"`
+	Email    string `json:"email" binding:"required,email"`
+}
+
 // UserSwagger se usa en la documentacion ya que Swaggo no reconoce
 // los tags de gorms
 type UserSwagger struct {


### PR DESCRIPTION
Add POST /auth/register with input validation (username 3-100 chars, password min 8 chars, valid email). Creates user via UserService, generates JWT token, returns 201 with token and user data. Returns 409 on duplicate username.