### PR TITLE
feat: implement refresh token flow with token rotation

### DIFF
--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -32,6 +32,12 @@ func SetupRoutes(router *gin.RouterGroup, userController controllers.UserControl
 	{
 		authRoutes.POST("/login", authLimiter.Middleware(), authController.Login)
 		authRoutes.POST("/register", authLimiter.Middleware(), authController.Register)
+		authRoutes.POST("/refresh", authLimiter.Middleware(), authController.RefreshToken)
+
+		// Logout requiere estar autenticado
+		protectedAuthRoutes := authRoutes.Group("")
+		protectedAuthRoutes.Use(middlewares.AuthMiddleware)
+		protectedAuthRoutes.POST("/logout", authController.Logout)
 	}
 
     VideoRoutes := router.Group("/streaming")

--- a/internal/services/authService.go
+++ b/internal/services/authService.go
@@ -1,6 +1,8 @@
 package services
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"time"
 
@@ -14,12 +16,20 @@ type AuthServiceImp struct{
 	userService UserService
 }
 
-type AuthService interface {
+type TokenPair struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+}
 
+type AuthService interface {
 	GenerateToken(User *models.User) (string, error)
 	ValidateToken(token string) (*models.User, error)
-	Login(username, password string) (string, error)
-
+	Login(username, password string) (*TokenPair, error)
+	GenerateRefreshToken(user *models.User) (string, error)
+	ValidateRefreshToken(tokenString string) (*models.User, error)
+	SaveRefreshToken(userId, refreshToken string) error
+	ClearRefreshToken(userId string) error
+	RefreshTokens(refreshToken string) (*TokenPair, error)
 }
 
 func NewAuthService() AuthService {
@@ -28,34 +38,39 @@ func NewAuthService() AuthService {
 	}
 }
 
-func (service *AuthServiceImp) Login(username, password string) (string, error) {
-	// Buscar el usuario en la base de datos
-
+func (service *AuthServiceImp) Login(username, password string) (*TokenPair, error) {
 	_, err := config.GetDB()
-
 	if err != nil {
-		return "", fmt.Errorf("error al conectar a la base de datos: %v", err)
+		return nil, fmt.Errorf("error al conectar a la base de datos: %v", err)
 	}
 
 	user, err := service.userService.GetUserByUserName(username)
-
 	if err != nil {
-		return "", fmt.Errorf("error al buscar el usuario: %v", err)
+		return nil, fmt.Errorf("error al buscar el usuario: %v", err)
 	}
 
-	// Verificar la contraseña
 	if !CheckPasswordHash(password, user.Password) {
-		return "", fmt.Errorf("la contraseña no es válida")
+		return nil, fmt.Errorf("la contraseña no es válida")
 	}
 
-	// Generar el token
-	token, err := service.GenerateToken(user)
-
+	accessToken, err := service.GenerateToken(user)
 	if err != nil {
-		return "", fmt.Errorf("error al generar el token: %v", err)
+		return nil, fmt.Errorf("error al generar el access token: %v", err)
 	}
 
-	return token, nil
+	refreshToken, err := service.GenerateRefreshToken(user)
+	if err != nil {
+		return nil, fmt.Errorf("error al generar el refresh token: %v", err)
+	}
+
+	if err := service.SaveRefreshToken(user.Id, refreshToken); err != nil {
+		return nil, fmt.Errorf("error al guardar el refresh token: %v", err)
+	}
+
+	return &TokenPair{
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+	}, nil
 }
 
 func (service *AuthServiceImp) GenerateToken(user *models.User) (string, error) {
@@ -140,9 +155,132 @@ func HashPassword(password string) (string, error) {
 
 // Función para comparar una contraseña sin hashear con su hash
 func CheckPasswordHash(password, hashedPassword string) bool {
-	// Comparar la contraseña con el hash
 	err := bcrypt.CompareHashAndPassword([]byte(hashedPassword), []byte(password))
-	return err == nil // Devuelve true si no hubo errores
+	return err == nil
 }
 
+// hashSHA256 genera un hash SHA-256 determinístico (rápido, suficiente para tokens aleatorios)
+func hashSHA256(input string) string {
+	h := sha256.Sum256([]byte(input))
+	return hex.EncodeToString(h[:])
+}
 
+// GenerateRefreshToken genera un JWT de refresh con exp de 7 días.
+// Contiene el user_id para poder hacer lookup directo en DB.
+func (service *AuthServiceImp) GenerateRefreshToken(user *models.User) (string, error) {
+	secretToken := []byte(config.GetConfig().JWTSecretKey)
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"user_id": user.Id,
+		"type":    "refresh",
+		"exp":     time.Now().Add(7 * 24 * time.Hour).Unix(),
+	})
+
+	tokenString, err := token.SignedString(secretToken)
+	if err != nil {
+		return "", fmt.Errorf("error signing refresh token: %v", err)
+	}
+
+	return tokenString, nil
+}
+
+// ValidateRefreshToken parsea el JWT para obtener user_id,
+// busca al usuario en DB y compara el hash SHA-256 almacenado.
+func (service *AuthServiceImp) ValidateRefreshToken(refreshToken string) (*models.User, error) {
+	secretToken := []byte(config.GetConfig().JWTSecretKey)
+
+	parsedToken, err := jwt.Parse(refreshToken, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
+		return secretToken, nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("invalid refresh token: %v", err)
+	}
+
+	claims, ok := parsedToken.Claims.(jwt.MapClaims)
+	if !ok || !parsedToken.Valid {
+		return nil, fmt.Errorf("invalid refresh token claims")
+	}
+
+	tokenType, _ := claims["type"].(string)
+	if tokenType != "refresh" {
+		return nil, fmt.Errorf("token is not a refresh token")
+	}
+
+	userId, ok := claims["user_id"].(string)
+	if !ok {
+		return nil, fmt.Errorf("invalid user_id in refresh token")
+	}
+
+	// Lookup directo por user_id (O(1), no iterar todos los usuarios)
+	user, err := service.userService.GetUserByID(userId)
+	if err != nil {
+		return nil, fmt.Errorf("user not found: %v", err)
+	}
+
+	// Comparar hash SHA-256 almacenado con el del token recibido
+	if user.RefreshToken == "" || user.RefreshToken != hashSHA256(refreshToken) {
+		return nil, fmt.Errorf("refresh token has been revoked")
+	}
+
+	return user, nil
+}
+
+// SaveRefreshToken guarda un hash SHA-256 del refresh token en la DB
+func (service *AuthServiceImp) SaveRefreshToken(userId, refreshToken string) error {
+	db, err := config.GetDB()
+	if err != nil {
+		return fmt.Errorf("error connecting to database: %v", err)
+	}
+
+	hashed := hashSHA256(refreshToken)
+
+	if err := db.Model(&models.User{}).Where("id = ?", userId).Update("refresh_token", hashed).Error; err != nil {
+		return fmt.Errorf("error saving refresh token: %v", err)
+	}
+
+	return nil
+}
+
+// ClearRefreshToken limpia el refresh token del usuario (logout)
+func (service *AuthServiceImp) ClearRefreshToken(userId string) error {
+	db, err := config.GetDB()
+	if err != nil {
+		return fmt.Errorf("error connecting to database: %v", err)
+	}
+
+	if err := db.Model(&models.User{}).Where("id = ?", userId).Update("refresh_token", "").Error; err != nil {
+		return fmt.Errorf("error clearing refresh token: %v", err)
+	}
+
+	return nil
+}
+
+// RefreshTokens valida el refresh token actual y genera un nuevo par de tokens (rotation)
+func (service *AuthServiceImp) RefreshTokens(refreshToken string) (*TokenPair, error) {
+	user, err := service.ValidateRefreshToken(refreshToken)
+	if err != nil {
+		return nil, err
+	}
+
+	accessToken, err := service.GenerateToken(user)
+	if err != nil {
+		return nil, fmt.Errorf("error generating access token: %v", err)
+	}
+
+	newRefreshToken, err := service.GenerateRefreshToken(user)
+	if err != nil {
+		return nil, fmt.Errorf("error generating refresh token: %v", err)
+	}
+
+	if err := service.SaveRefreshToken(user.Id, newRefreshToken); err != nil {
+		return nil, fmt.Errorf("error saving refresh token: %v", err)
+	}
+
+	return &TokenPair{
+		AccessToken:  accessToken,
+		RefreshToken: newRefreshToken,
+	}, nil
+}


### PR DESCRIPTION
Add JWT-based refresh tokens (7d expiry) with SHA-256 hash stored in DB. Lookup by user_id from JWT claims (O(1), no full table scan). Includes token rotation on refresh (old token invalidated). Add POST /auth/refresh and POST /auth/logout (protected) endpoints.