### PR TITLE
feat: add health check endpoints

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,13 @@ services:
       - rabbitmq
     volumes:
       - .:/app
-    command: ["go", "run", "main.go"] # Comando para INICIAR EL SERVIDOR
+    command: ["go", "run", "main.go"]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3003/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
 
 volumes:
   postgres_data:

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"net/http"
 	"strings"
 
 	"github.com/gin-contrib/cors"
@@ -13,6 +14,7 @@ import (
 	"github.com/unbot2313/go-streaming-service/internal/app"
 	"github.com/unbot2313/go-streaming-service/internal/middlewares"
 	"github.com/unbot2313/go-streaming-service/internal/routes"
+	"github.com/unbot2313/go-streaming-service/internal/services"
 )
 
 // @title Go Streaming Service API
@@ -63,6 +65,42 @@ func main() {
 	// Configurar la documentación de Swagger
 	r.GET("/docs/*any", ginSwagger.WrapHandler(swaggerfiles.Handler))
 
+
+	// Health check endpoints (fuera de /api/v1, sin auth ni rate limit)
+	r.GET("/health", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"status": "ok"})
+	})
+
+	r.GET("/ready", func(c *gin.Context) {
+		checks := gin.H{}
+
+		// Check DB
+		db, err := config.GetDB()
+		if err != nil {
+			checks["database"] = "error: " + err.Error()
+			c.JSON(http.StatusServiceUnavailable, gin.H{"status": "not ready", "checks": checks})
+			return
+		}
+		sqlDB, err := db.DB()
+		if err != nil || sqlDB.Ping() != nil {
+			checks["database"] = "unreachable"
+			c.JSON(http.StatusServiceUnavailable, gin.H{"status": "not ready", "checks": checks})
+			return
+		}
+		checks["database"] = "ok"
+
+		// Check RabbitMQ
+		rabbitService := services.NewRabbitMQService()
+		if err := rabbitService.Connect(); err != nil {
+			checks["rabbitmq"] = "unreachable"
+			c.JSON(http.StatusServiceUnavailable, gin.H{"status": "not ready", "checks": checks})
+			return
+		}
+		rabbitService.Close()
+		checks["rabbitmq"] = "ok"
+
+		c.JSON(http.StatusOK, gin.H{"status": "ready", "checks": checks})
+	})
 
 	r.Run(":3003")
 


### PR DESCRIPTION
GET /health returns 200 {"status":"ok"} (liveness probe). GET /ready checks DB ping and RabbitMQ connectivity, returns 200 if both are reachable or 503 with failing check details. Add healthcheck config to docker-compose app service.