### PR TITLE
fix: use persistent RabbitMQ connection instead of per-upload

### DIFF
--- a/internal/app/initializer.go
+++ b/internal/app/initializer.go
@@ -23,9 +23,12 @@ func InitializeComponents() (controllers.UserController, controllers.AuthControl
 	videoService := services.NewVideoService(storageService, filesService, ffmpegService)
 	databaseVideoService := services.NewDatabaseVideoService()
 
-	// Inicializa servicios de jobs y RabbitMQ
+	// Inicializa servicios de jobs y RabbitMQ (conexión persistente)
 	jobService := services.NewJobService()
 	rabbitMQService := services.NewRabbitMQService()
+	if err := rabbitMQService.Connect(); err != nil {
+		panic("Could not connect to RabbitMQ: " + err.Error())
+	}
 
 	// Inicializa controladores
 	videoController := controllers.NewVideoController(videoService, databaseVideoService, jobService, rabbitMQService)

--- a/internal/controllers/videoController.go
+++ b/internal/controllers/videoController.go
@@ -186,16 +186,7 @@ func (vc *VideoControllerImpl) CreateVideo(c *gin.Context) {
 		return
 	}
 
-	// 7. Conectar a RabbitMQ
-	err = vc.rabbitMQService.Connect()
-	if err != nil {
-		vc.jobService.UpdateJobStatus(createdJob.Id, "failed", "Error conectando a RabbitMQ")
-		helpers.HandleError(c, http.StatusInternalServerError, "Error conectando a cola de procesamiento", err)
-		return
-	}
-	defer vc.rabbitMQService.Close()
-
-	// 8. Crear y serializar tarea para la cola
+	// 7. Crear y serializar tarea para la cola
 	videoTask := models.VideoTask{
 		JobID:       createdJob.Id,
 		UserID:      authenticatedUser.Id,


### PR DESCRIPTION
Connect to RabbitMQ once during initialization and reuse the connection across all uploads. Remove Connect/Close calls from CreateVideo handler to avoid opening/closing a connection on every upload request.